### PR TITLE
Use cache Identifier by interpreted typoscript

### DIFF
--- a/Classes/Hooks/PageRendererHook.php
+++ b/Classes/Hooks/PageRendererHook.php
@@ -66,7 +66,8 @@ class PageRendererHook
         $cache = GeneralUtility::makeInstance(CacheManager::class)
             ->getCache('cache_hash');
 
-        $configCacheIdentifier = sha1('cdn_assets:configuration|' . $tsfe->id);
+        $configCacheIdentifier = sha1('cdn_assets:configuration|' . $tsfe->id . '|' . json_encode($tsfe->getConfigArray()));
+
         if (($extensionConfig = $cache->get($configCacheIdentifier)) === false) {
             $systemConfig = $tsfe->config;
 


### PR DESCRIPTION
The current cache identifier only reflects the give page-id. If a condition is added based on the type or the language this would not applied. 
The idea is to add the complete TS as identifier, since we don't know on which parameter / value a condition is applied. 