### PR TITLE
Use different config cache keys based on current page ID and TSFE config

### DIFF
--- a/Classes/Hooks/PageRendererHook.php
+++ b/Classes/Hooks/PageRendererHook.php
@@ -65,7 +65,7 @@ class PageRendererHook
         /** @var FrontendInterface $cache */
         $cache = GeneralUtility::makeInstance(CacheManager::class)
             ->getCache('cache_hash');
-        
+
         $tsfe->getConfigArray();
         $configCacheIdentifier = sha1('cdn_assets:configuration|' . $tsfe->id . '|' . json_encode($tsfe->config));
 

--- a/Classes/Hooks/PageRendererHook.php
+++ b/Classes/Hooks/PageRendererHook.php
@@ -66,7 +66,8 @@ class PageRendererHook
         $cache = GeneralUtility::makeInstance(CacheManager::class)
             ->getCache('cache_hash');
 
-        $configCacheIdentifier = sha1('cdn_assets:configuration|' . $tsfe->id);
+        $configCacheIdentifier = sha1('cdn_assets:configuration|' . $tsfe->id . '|' . json_encode($tsfe->getConfigArray()));
+
         if (($extensionConfig = $cache->get($configCacheIdentifier)) === false) {
             $systemConfig = $tsfe->config;
 

--- a/Classes/Hooks/PageRendererHook.php
+++ b/Classes/Hooks/PageRendererHook.php
@@ -65,8 +65,9 @@ class PageRendererHook
         /** @var FrontendInterface $cache */
         $cache = GeneralUtility::makeInstance(CacheManager::class)
             ->getCache('cache_hash');
-
-        $configCacheIdentifier = sha1('cdn_assets:configuration|' . $tsfe->id . '|' . json_encode($tsfe->getConfigArray()));
+        
+        $tsfe->getConfigArray();
+        $configCacheIdentifier = sha1('cdn_assets:configuration|' . $tsfe->id . '|' . json_encode($tsfe->config));
 
         if (($extensionConfig = $cache->get($configCacheIdentifier)) === false) {
             $systemConfig = $tsfe->config;


### PR DESCRIPTION
The current cache identifier is the page id. If you are using conditions based on language, site, host or type the cache identifier won't identify the different TS Configurations.

This pull requests adds the TS configuration to the cache identifier, thus any condition inside TS would be applied when building the cache.